### PR TITLE
Allow overriding SceneDetectionAlgorithm at runtime

### DIFF
--- a/pkg/agent/tasks/lib/scenedetection/base.py
+++ b/pkg/agent/tasks/lib/scenedetection/base.py
@@ -22,19 +22,45 @@ class SceneDetectionAlgorithm(ABC):
     def __init__(self):
         self.logger = logging.getLogger('SceneDetectionAlgorithm')
 
-    # The main method of the SceneDetectionAlgorithm. Override this in your base class
-    # TODO: Must return `timestamps`, `frame_cuts`, and `everyN` as part of the results
     @abstractmethod
     def find_scenes(self, video_path):
+        """
+        The main method of the SceneDetectionAlgorithm. Override this in your subclass.
+
+        Parameters:
+        video_path (string): Video path
+
+        Returns:
+        string: Features of detected scenes
+        """
         pass
 
-    # Given a video path, return directory and filename (minus extension) as separate values
     def parse_dir_and_filename(self, video_path):
+        """
+        Given a video path, return directory and filename (minus extension) as separate values.
+
+        Parameters:
+        video_path (string): Video path
+
+        Returns:
+        directory (string): directory for the given path
+        short_file_name (string): the base filename for the given path (minus extension)
+        """
         short_file_name = os.path.basename(video_path)[:video_path.find('.')]
         directory = os.path.dirname(video_path)
         return directory, short_file_name
 
     def run_as_subprocess(self, target, args):
+        """
+        Run a method as a subprocess using a result queue to return items, wait for completion, and return the result.
+
+        Parameters:
+        target (Function): Function to call as a subprocess
+        args (list of object): Arguments to pass to the subprocess function
+
+        Returns:
+        anything: the return type of the target Function
+        """
         result_queue = Queue()
         p = Process(target=target, args=(result_queue, args,))
 
@@ -46,12 +72,8 @@ class SceneDetectionAlgorithm(ABC):
         return results
 
     def extract_scene_information(self, video_path, timestamps, frame_cuts, everyN, start_time):
-        args = (video_path, timestamps, frame_cuts, everyN, start_time)
-        return self.run_as_subprocess(target=self._extract_scene_information, args=args)
-
-    def _extract_scene_information(self, result_queue, args):
         """
-        Extract useful features from each detected scenes and output scene images.
+        Wrapper to extract useful features from each detected scenes and output scene images as a subprocess.
 
         Parameters:
         video_path (string): Video path
@@ -61,7 +83,21 @@ class SceneDetectionAlgorithm(ABC):
         start_time (list of float): Start time of the whole process
 
         Returns:
-        string: Features of detected scene as JSOH
+        string: Features of detected scenes
+        """
+        args = (video_path, timestamps, frame_cuts, everyN, start_time)
+        return self.run_as_subprocess(target=self._extract_scene_information, args=args)
+
+    def _extract_scene_information(self, result_queue, args):
+        """
+        Internal helper method to extract useful features from each detected scenes and output scene images.
+
+        Parameters:
+        video_path (string): Video path
+        timestamps (list of float): Timestamp array for sample frames
+
+        Returns:
+        string: Features of detected scenes
         """
         (video_path, timestamps, frame_cuts, everyN, start_time) = args
 

--- a/pkg/agent/tasks/lib/scenedetection/example.py
+++ b/pkg/agent/tasks/lib/scenedetection/example.py
@@ -1,34 +1,46 @@
 from time import perf_counter
 
-import numpy as np
-
 from pkg.agent.tasks.lib.scenedetection.base import SceneDetectionAlgorithm
 
 
-# Write algorithm code up here
 
-class SimStructuralV1(SceneDetectionAlgorithm):
+
+# Write static code here
+
+
+
+
+class ExampleV1(SceneDetectionAlgorithm):
 
     def find_scenes(self, video_path):
-        # Record how long the task takes and return that at the end
+        """
+        The main method of the SceneDetectionAlgorithm. Override this in your subclass.
+
+        Parameters:
+        video_path (string): Video path
+
+        Returns:
+        string: Features of detected scenes
+        """
+        # This should return an array of scenes
+        scenes = []
+
         start_time = perf_counter()
 
-        self.logger.info('Given a video path, this method will parse the video to look for possible scene candidates.')
+        self.logger.info('Given a video path, this method will parse the video and build up a list of scenes.')
 
+        self.logger.info('To run a method as a subprocess (in case of resource leaks), '
+                         'you can use self.run_as_subprocess')
 
-        self.logger.info('To run as a subprocess (in case of memory leaks), you can use self.run_as_subprocess')
+        end_time = perf_counter()
+        self.logger.info('perf_counter() can be used to further measure incremental task duration: %d ms' %
+                         (end_time - start_time))
 
-        num_samples = 10
-        # vr_full = decord.VideoReader(video_path, ctx=decord.cpu(0))
+        # must return array of detected scenes at the end
+        return scenes
 
-        timestamps = np.zeros(num_samples)
-        everyN = 1
-
-        # Now work in frames again. Make sure we are using regular ints (not numpy ints) other json serialization will fail
-        frame_cuts = [int(s * everyN) for s in sample_cuts]
-
-        # must return an array of timestamps, array of frame cut points, the sampling period, and the start time
-        return timestamps, frame_cuts, everyN, start_time
+        # If desired, a helper method has been included to cut the scenes and run OCR:
+        # return self.extract_scene_information(video_path, timestamps, frame_cuts, everyN, start_time)
 
 
 

--- a/pkg/agent/tasks/lib/scenedetector.py
+++ b/pkg/agent/tasks/lib/scenedetector.py
@@ -9,8 +9,8 @@ import importlib
 
 
 # Default to SimStructuralV1 implementation
-SCENE_DETECT_ALGORITHM_CLASS = os.getenv('SCENE_DETECT_ALGORITHM_CLASS', 'SimStructuralV1')
-SCENE_DETECT_ALGORITHM_MODULE = os.getenv('SCENE_DETECT_ALGORITHM_MODULE', 'pkg.agent.tasks.lib.scenedetection.sim_structural')
+SCENE_DETECT_ALGORITHM_CLASS = os.getenv('SCENE_DETECT_ALGORITHM_CLASS', 'ExampleV1')
+SCENE_DETECT_ALGORITHM_MODULE = os.getenv('SCENE_DETECT_ALGORITHM_MODULE', 'pkg.agent.tasks.lib.scenedetection.example')
 
 
 # Three sections:


### PR DESCRIPTION
## Problem
We would like to be able to easily add new algorithms for SceneDetection, and measure their performance in relation to one another.

## Approach
Refactored original `scenedetector` Python code into a `SceneDetectorAlgorithm` class.

User needs only to implement a new `SceneDectectionAlgorithm` subclass that includes `def find_scenes(self, video_path)`. This method accepts a `video_path` (string) and returns an array of detected scene information.

## How to Test
TBD