### PR TITLE
Fixed the error caused by directly casting String to int

### DIFF
--- a/pkg/agent/tasks/lib/scenedetection/base.py
+++ b/pkg/agent/tasks/lib/scenedetection/base.py
@@ -154,7 +154,7 @@ class SceneDetectionAlgorithm(ABC):
             last_block = -1
             phrase = []
             for i in range(len(str_text['conf'])):
-                if int(str_text['conf'][i]) >= OCR_CONFIDENCE and len(str_text['text'][i].strip()) > 0:
+                if int(float(str_text['conf'][i])) >= OCR_CONFIDENCE and len(str_text['text'][i].strip()) > 0:
                     curr_block = str_text['block_num'][i]
                     if curr_block != last_block:
                         if len(phrase) > 0:

--- a/pkg/agent/tasks/lib/scenedetection/sim_structural.py
+++ b/pkg/agent/tasks/lib/scenedetection/sim_structural.py
@@ -280,7 +280,7 @@ def generate_frame_similarity(video_path, num_samples, everyN, start_time):
 
                 phrases = Counter()
                 for j in range(len(str_text['conf'])):
-                    if int(str_text['conf'][j]) >= SIM_OCR_CONFIDENCE and len(str_text['text'][j].strip()) > 0:
+                    if int(float(str_text['conf'][j])) >= SIM_OCR_CONFIDENCE and len(str_text['text'][j].strip()) > 0:
                         phrases[str_text['text'][j]
                         ] += (float(str_text['conf'][j]) / 100)
 

--- a/pkg/agent/tasks/lib/titledetector.py
+++ b/pkg/agent/tasks/lib/titledetector.py
@@ -131,7 +131,7 @@ def title_detection(text_data, height, width):
     
     # Extract OCR outputs
     for i in range(len(text_data['conf'])):
-        if int(text_data['conf'][i]) >= OCR_CONFIDENCE and len(text_data['text'][i].strip()) > 0:
+        if int(float(text_data['conf'][i])) >= OCR_CONFIDENCE and len(text_data['text'][i].strip()) > 0:
             scaled_height = scale_by_text_height(text=text_data['text'][i], original_height=text_data['height'][i])
             
             words.append(text_data['text'][i])


### PR DESCRIPTION
# Problem
There is a protentical error caused by directly casting a String into an int with respect to different python versions. An example would be the following.
``` python
int(str_text['conf'][i])
```
that directly casts a String str_text['conf'][i] to an int type.

# Approach
First cast the String to an float, then cast it to an int
``` python
int(float(str_text['conf'][i]))
```