### PR TITLE
SceneDetection - fixed error at end, added try catch

### DIFF
--- a/pkg/agent/tasks/lib/scenedetection/base.py
+++ b/pkg/agent/tasks/lib/scenedetection/base.py
@@ -122,9 +122,14 @@ class SceneDetectionAlgorithm(ABC):
             print("Image extraction and OCR - Processing from " + str(start_idx) + " to " + str(end_idx))
 
             sema.acquire()
-            args = (video_path, timestamps, frame_cuts[start_idx: end_idx], everyN, start_time)
-            local_result = self.run_as_subprocess(target=self._extract_scene_information, args=args)
-            results.extend(local_result)
+            try:
+                args = (video_path, timestamps, frame_cuts[start_idx: end_idx], everyN, start_time)
+                local_result = self.run_as_subprocess(target=self._extract_scene_information, args=args)
+                results.extend(local_result)
+
+            except Exception as e:
+                print(f"_extract_scene_information throwing Exception:" + str(e))
+
             sema.release()
         
         print("Image extraction and OCR - " + str(len(results)) + " extracted!")


### PR DESCRIPTION
## Problems
- cv2.resize error at the end of the video
- SD stops completely when exception happens, when it should continue

## Observation
- NUM_OF_FRAME reported by cv2 is not reliable in some videos

## Approach
- Check readable frame for null, stop the iteration when read a null
- Add try catch statements on Scene Analysis and Image extraction, so as the program proceeds even excepts on some frames