### PR TITLE
Glossary algo domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-slim
 
 # Install OS dependencies
 RUN apt-get -qq update && \
-    apt-get -qq install --no-install-recommends netcat curl git wget ffmpeg build-essential libsm6 libxext6 libxrender-dev automake libtool pkg-config libsdl-pango-dev libicu-dev libcairo2-dev bc libleptonica-dev && \
+    apt-get -qq install --no-install-recommends vim-tiny netcat curl git wget ffmpeg build-essential libsm6 libxext6 libxrender-dev automake libtool pkg-config libsdl-pango-dev libicu-dev libcairo2-dev bc libleptonica-dev && \
     apt-get -qq clean autoclean && \
     apt-get -qq autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-slim
 
 # Install OS dependencies
 RUN apt-get -qq update && \
-    apt-get -qq install --no-install-recommends vim-tiny netcat curl git wget ffmpeg build-essential libsm6 libxext6 libxrender-dev automake libtool pkg-config libsdl-pango-dev libicu-dev libcairo2-dev bc libleptonica-dev && \
+    apt-get -qq install --no-install-recommends netcat curl git wget ffmpeg build-essential libsm6 libxext6 libxrender-dev automake libtool pkg-config libsdl-pango-dev libicu-dev libcairo2-dev bc libleptonica-dev && \
     apt-get -qq clean autoclean && \
     apt-get -qq autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -31,8 +31,9 @@ WORKDIR /usr/app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Additional dependencies for brown corpus/stopwords
+# Additional dependencies for brown corpus/stopwords, wordnet
 RUN python -m nltk.downloader brown stopwords
+RUN python -m nltk.downloader wordnet omw-1.4
 
 # Copy in Python source
 COPY . .

--- a/pkg/agent/tasks/AbstractTask.py
+++ b/pkg/agent/tasks/AbstractTask.py
@@ -119,10 +119,6 @@ class AbstractTask(ABC):
     def update_jwt(self):
         # update jwt token
         try:
-            print('current time: ' + str(time.mktime(time.gmtime())))
-            if 'JWT_LAST_UPDATE' in os.environ:
-                print('last time: ' + str(os.getenv('TARGET_HOST_JWT')))
-
             if ('JWT_LAST_UPDATE' not in os.environ) or (time.mktime(time.gmtime()) - float(os.getenv('JWT_LAST_UPDATE')) > JWT_UPDATE_INTERVAL):
                 #resp = requests.get(url='%s/api/Account/MediaWorkerSignIn?access=%s' % (TARGET_HOST, LOCAL_SECRET))
                 resp = requests.post(url='%s/api/Account/MediaWorkerSignIn' % (TARGET_HOST),
@@ -143,4 +139,4 @@ class AbstractTask(ABC):
                 self.logger.error("No updates to jwt token since it is still valid: %s", os.getenv('TARGET_HOST_JWT'))
         except (requests.exceptions.RequestException, requests.exceptions.HTTPError) as e:
             self.logger.error("Failed to update jwt token: %s", e)
-            return 'null'
+            return ''

--- a/pkg/agent/tasks/AccessibleGlossary.py
+++ b/pkg/agent/tasks/AccessibleGlossary.py
@@ -28,7 +28,7 @@ class AccessibleGlossary(AbstractTask):
 
         try:
             self.logger.info(' [%s] AccessibleGlossary generating term descriptions...' % video_id)
-            terms, descriptions = accessibleglossary.look_up(phrase_hints)
+            glossary = accessibleglossary.look_up(phrase_hints)
 
             if readonly:
                 self.logger.info(' [%s] AccessibleGlossary running as READONLY.. term descriptions have not been saved: %s' % (video_id, terms.join('')))
@@ -37,7 +37,7 @@ class AccessibleGlossary(AbstractTask):
                 self.jwt = self.update_jwt()
                 resp = requests.post(url='%s/api/Task/UpdateGlossary?videoId=%s' % (self.target_host, video_id),
                                      headers={'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % self.jwt},
-                                     data=json.dumps({"Terms": terms, "Descriptions": descriptions}))
+                                     data=json.dumps({"Glossary": glossary}))
                 resp.raise_for_status()
 
             return video

--- a/pkg/agent/tasks/lib/accessibleglossary.py
+++ b/pkg/agent/tasks/lib/accessibleglossary.py
@@ -1,27 +1,80 @@
 import logging
+import wikipedia
 import wikipediaapi
+from nltk.corpus import wordnet as wn
 
 logger = logging.getLogger('pkg.agent.tasks.lib.accessibleglossary')
 wiki_en = wikipediaapi.Wikipedia('en')
 
-def get_one_sentence_description(term):
+def look_up_wordnet(term):
+    '''
+    Currently not in used
+    '''
+    wn_term = wn.synsets(term, pos = wn.NOUN)
+    if len(wn_term) != 0:
+        return wn_term[0].definition()
+    else:
+        return 'Not available'
+
+def get_one_sentence_wiki(term):
+    if wiki_en.page(term).exists() == False:
+        return 'Not available'
+    
     summary = wiki_en.page(term).summary
     firstPeriod = summary.index('.') if '.' in summary else len(summary) - 1
     sentence = summary[0: firstPeriod + 1]
+    if ' may refer to:' in sentence:
+        return 'Ambiguous meaning'
+    
     return sentence
+
+def get_domain_wiki(raw_results):
+    domains = []
+    filtered_results = []
+    wiki_term = raw_results[0]
+    
+    for entry in raw_results:
+        if '(' in entry and ')' in entry and entry.index('(') < entry.index(')'):
+            start = entry.index('(') + 1
+            end = entry.index(')')
+            domain = entry[start : end]
+            
+            if entry[ : len(wiki_term)] != wiki_term:
+                continue
+            if domain == 'disambiguation':
+                continue
+            domains.append(domain)
+        else:
+            filtered_results.append(entry)
+            
+    return domains, filtered_results
+
+def look_up_wiki(term):
+    integrated_result = []
+    search_results = wikipedia.search(term).copy()
+    if len(search_results) == 0:
+        return integrated_result
+    
+    wiki_term = search_results[0]
+    domains, filtered_results = get_domain_wiki(search_results)
+    for i in range(min(2, len(filtered_results))):
+        formated_term = '_'.join(filtered_results[i].split(' '))
+        integrated_result.append([filtered_results[i], get_one_sentence_wiki(formated_term), 'General', 'Wikipedia'])
+
+    for domain in domains:
+        formated_term = term + '_(' + '_'.join(domain.split(' ')) + ')'
+        integrated_result.append([wiki_term, get_one_sentence_wiki(formated_term), domain, 'Wikipedia'])
+        
+    return integrated_result
 
 def look_up(phrase_hints):
     raw_terms = phrase_hints.splitlines()
 
-    extracted_terms = []
-    descriptions = []
-
+    glossary = []
     for term in raw_terms:
-        if wiki_en.page(term).exists():
-            extracted_terms.append(term)
-            descriptions.append(get_one_sentence_description(term))
-    
-    for i in range(len(extracted_terms)):
-        print(str(extracted_terms[i]) + ' -> ' + str(descriptions[i]))
+        glossary.extend(look_up_wiki(term))
 
-    return extracted_terms, descriptions
+    for i in range(len(glossary)):
+        print(str(glossary[i][0]) + ' -> ' + str(glossary[i][1]) + ' -> ' + str(glossary[i][2]))
+
+    return glossary

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ sklearn==0.0
 
 # glossary
 wikipedia-api==0.5.4
+wikipedia==1.4.0


### PR DESCRIPTION
## Problem
- The mechanism how glossary looking up words from Wikipedia needs optimization

## Approach
- Introducing Accessible Glossary v1.1
- For a term A, if description in multiple domains are available, save description + domain of A for each domain
- Save the description of the most related term of A defined by the Wikipedia, if available
- Example output of looking up for term 'Java' with Accessible Glossary
`['Java',
  'Java (Indonesian: Jawa, Indonesian pronunciation: [ˈdʒawa]; Javanese: ꦗꦮ; Sundanese: ᮏᮝ) is one of the Greater Sunda Islands in Indonesia.',
  'General',
  'Wikipedia']`
` ['JavaScript',
  'JavaScript (), often abbreviated to JS, is a programming language that is one of the core technologies of the World Wide Web, alongside HTML and CSS.',
  'General',
  'Wikipedia']`
`['Java',
  'Java is a high-level, class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible.',
  'programming language',
  'Wikipedia']`
 `['Java',
  'Java is a set of computer software and specifications developed by James Gosling at Sun Microsystems, which was later acquired by the Oracle Corporation, that provides a system for developing application software and deploying it in a cross-platform computing environment.',
  'software platform',
  'Wikipedia']`