### PR TITLE
Glossary - Checked period in Prefix Abbreviation, 12 Hour Clock, Adde…

### DIFF
--- a/pkg/agent/tasks/lib/accessibleglossary.py
+++ b/pkg/agent/tasks/lib/accessibleglossary.py
@@ -6,6 +6,8 @@ from nltk.corpus import wordnet as wn
 logger = logging.getLogger('pkg.agent.tasks.lib.accessibleglossary')
 wiki_en = wikipediaapi.Wikipedia('en')
 
+PREFIXES = ['Dr', 'Gov', 'Miss', 'Mr', 'Mrs', 'Ms', 'Pres', 'Prof', 'Rep', 'Jr', 'Sr']
+
 def look_up_wordnet(term):
     '''
     Currently not in used
@@ -16,17 +18,44 @@ def look_up_wordnet(term):
     else:
         return 'Not available'
 
-def get_one_sentence_wiki(term):
+def first_valid_period(sentence, prefixes=PREFIXES):
+    if '.' not in sentence:
+        return len(sentence)
+    
+    first_period = sentence.index('.')
+    
+    # Check for prefix abbreviations
+    for pre in prefixes:
+        pre_start = first_period - len(pre)
+        if pre_start < 0:
+            continue
+        
+        if sentence[pre_start : first_period] == pre:
+            return first_period + 1 + first_valid_period(sentence[first_period + 1 :], prefixes)
+    
+    # Check for 12-hour clock
+    prev_1 = sentence[first_period - 1] if first_period - 1 >= 0 else ''
+    prev_2 = sentence[first_period - 2] if first_period - 2 >= 0 else ''
+    next_1 = sentence[first_period + 1] if first_period + 1 < len(sentence) else ''
+    if next_1 == 'm' and (prev_1 == 'a' or prev_1 == 'p'):
+        return first_period + 1 + first_valid_period(sentence[first_period + 1 :], prefixes)
+    if prev_1 == 'm' and prev_2 == '':
+        return first_period + 1 + first_valid_period(sentence[first_period + 1 :], prefixes)
+    
+    return first_period
+
+def get_one_sentence_and_url(term):
     if wiki_en.page(term).exists() == False:
-        return 'Not available'
+        return 'Not available', 'Not available'
     
     summary = wiki_en.page(term).summary
-    firstPeriod = summary.index('.') if '.' in summary else len(summary) - 1
-    sentence = summary[0: firstPeriod + 1]
+    url = wiki_en.page(term).fullurl
+    first_period = first_valid_period(summary)
+    sentence = summary[0: first_period + 1]
     if ' may refer to:' in sentence:
-        return 'Ambiguous meaning'
+        return 'Ambiguous meaning', url
     
-    return sentence
+    return sentence, url
 
 def get_domain_wiki(raw_results):
     domains = []
@@ -59,11 +88,13 @@ def look_up_wiki(term):
     domains, filtered_results = get_domain_wiki(search_results)
     for i in range(min(2, len(filtered_results))):
         formated_term = '_'.join(filtered_results[i].split(' '))
-        integrated_result.append([filtered_results[i], get_one_sentence_wiki(formated_term), 'General', 'Wikipedia'])
+        sentence, url = get_one_sentence_and_url(formated_term)
+        integrated_result.append([filtered_results[i], sentence, 'General', 'Wikipedia', url])
 
     for domain in domains:
         formated_term = term + '_(' + '_'.join(domain.split(' ')) + ')'
-        integrated_result.append([wiki_term, get_one_sentence_wiki(formated_term), domain, 'Wikipedia'])
+        sentence, url = get_one_sentence_and_url(formated_term)
+        integrated_result.append([wiki_term, sentence, domain, 'Wikipedia', url])
         
     return integrated_result
 


### PR DESCRIPTION
## Problem
- PyApi Accessible Glossary needs Improvement

## Approach
- When extracting one-sentence-description of a term from Wikipedia, the algorithm now ignores the period in the middle of a sentence due to prefix abbreviation (Dr.) and 12 hour clock (12 p.m.)
- The algorithm now also extracts the Wikipedia URL of a searched term