### PR TITLE
psycopg2-binary 2.9.3 to 2.9.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ marshmallow-sqlalchemy==0.27.0
 marshmallow==3.14.1
 flask-marshmallow==0.14.0
 SQLAlchemy==1.4.31
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5
 
 # RabbitMQ
 pika==1.2.0


### PR DESCRIPTION
## Problem
- psycopg2-binary failed the docker build

## Approach
- change psycopg2-binary version from 2.9.3 to 2.9.5